### PR TITLE
now ConnString is stored in appsettings

### DIFF
--- a/EbikeCommerce/DBmodel/DBservice.cs
+++ b/EbikeCommerce/DBmodel/DBservice.cs
@@ -5,7 +5,7 @@ namespace EbikeCommerce.DBmodel
 {
     public static class DBservice
     {
-        static readonly string ConnString = "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EBikeCommerce;Integrated Security=True;";
+        public static string? ConnString { get; set; } = string.Empty;
 
         public static async Task<List<ProductRecord>> OnGetDataAsync()
         {

--- a/EbikeCommerce/DBmodel/Record.cs
+++ b/EbikeCommerce/DBmodel/Record.cs
@@ -82,4 +82,9 @@
         public int expiration_year { get; set; }
         public required string cvv { get; set; }
     }
+
+    public record Settings
+    {
+        public required string ConnString { get; set; }
+    }
 }

--- a/EbikeCommerce/Program.cs
+++ b/EbikeCommerce/Program.cs
@@ -1,3 +1,4 @@
+using EbikeCommerce.DBmodel;
 using Microsoft.AspNetCore.Authentication.Cookies;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,6 +7,8 @@ builder.Services.AddSession(options =>
 {
     options.IdleTimeout = TimeSpan.FromMinutes(60);
 });
+
+DBservice.ConnString = builder.Configuration.GetSection(nameof(Settings)).GetValue<string>("ConnString");
 
 builder.Services.AddRazorPages();
 

--- a/EbikeCommerce/appsettings.Development.json
+++ b/EbikeCommerce/appsettings.Development.json
@@ -5,5 +5,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+
+  "Settings": {
+    "ConnString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=EBikeCommerce;Integrated Security=True;"
   }
 }

--- a/EbikeCommerce/appsettings.json
+++ b/EbikeCommerce/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "Settings": {
+    "ConnString":  ""
+  }
 }


### PR DESCRIPTION
#### PR Classification
Modifica della configurazione della stringa di connessione al database.

#### PR Summary
La stringa di connessione al database è stata resa configurabile tramite il file di configurazione.
- `DBservice.cs`: La stringa di connessione `ConnString` è stata trasformata in una proprietà pubblica e modificabile.
- `Record.cs`: Aggiunto un nuovo record `Settings` con una proprietà `ConnString` obbligatoria.
- `Program.cs`: La stringa di connessione `ConnString` viene ora letta dalla sezione `Settings` del file di configurazione.
- `appsettings.Development.json` e `appsettings.json`: Aggiunta una nuova sezione `Settings` con una chiave `ConnString`.
